### PR TITLE
Report test failures to shippable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,21 @@ AX_VALGRIND_CHECK
 # test coverage with gcov and reporting with lcov
 AX_CODE_COVERAGE
 
+# Address Sanitizer
+AC_MSG_CHECKING([whether to enable ASan])
+AC_ARG_ENABLE([asan],
+    [AS_HELP_STRING([--enable-asan], [Build with GCC Address Sanitizer instrumentation])],
+    [],
+    [enable_asan=no])
+AM_CONDITIONAL([ENABLE_ASAN], [test "x$enable_asan" = "xyes"])
+AC_SUBST([ENABLE_ASAN])
+AM_COND_IF([ENABLE_ASAN], [
+   AC_MSG_RESULT([yes])
+   CFLAGS="${CFLAGS} -fsanitize=address"
+], [
+   AC_MSG_RESULT([no])
+])
+
 # ZeroMQ and high-level C wrapper (CZMQ)
 PKG_CHECK_MODULES([libzmq], [libzmq >= 4.1])
 PKG_CHECK_MODULES([libczmq], [libczmq >= 3.0])
@@ -93,8 +108,9 @@ AC_ARG_ENABLE([debug],
     [],
     [enable_debug=no])
 AS_IF([test "x$enable_debug" = "xyes"], [
-    AC_DEFINE(DEBUG, [1], [Debug messages.])
+    AC_DEFINE(DEBUG, [1], [Produce a debug build])
 ])
+AM_CONDITIONAL([DEBUG_BUILD], [test "x$enable_debug" = "xyes"])
 
 # documentation
 AC_ARG_ENABLE([docs],
@@ -115,6 +131,7 @@ AM_CFLAGS="-Wall \
     -Wsign-compare -Wchar-subscripts \
     -Wstrict-prototypes -Wshadow \
     -Wformat-security -Wtype-limits \
+    -fstack-protector \
     -ffunction-sections \
     -fdata-sections \
     -pthread \

--- a/shippable.yml
+++ b/shippable.yml
@@ -19,7 +19,7 @@ build:
     - sudo apt-get update
     - ./install-build-deps.sh
     - ./autogen.sh
-    - ./configure --enable-debug --enable-code-coverage --enable-valgrind --with-glip
+    - ./configure --enable-debug --enable-code-coverage --enable-valgrind --with-glip --enable-asan
     - make
     - make check-code-coverage
     - make check-valgrind
@@ -39,7 +39,8 @@ build:
 
   on_failure:
     # Dump test logs to stdout for debugging test failures
-    - for f in tests/unit/*.log; do echo "======= TEST LOG $f ======="; cat $f; done
+    - cat tests/unit/test-suite.log
+    - cat tests/unit/test-suite-memcheck.log
 
     # Copy test results where shippable.io finds them
     - make -C tests/unit check-junit-xml

--- a/shippable.yml
+++ b/shippable.yml
@@ -19,18 +19,28 @@ build:
     - sudo apt-get update
     - ./install-build-deps.sh
     - ./autogen.sh
-    - ./configure --enable-debug --enable-code-coverage --enable-valgrind
+    - ./configure --enable-debug --enable-code-coverage --enable-valgrind --with-glip
     - make
     - make check-code-coverage
     - make check-valgrind
 
-    # Copy test results where shippable.io finds them
-    - make -C tests/unit check-junit-xml
-    - cp tests/unit/*.junit.xml shippable/testresults
-
+  post_ci:
     # Copy code coverage information where shippable.io finds it
     - make -C tests/unit coverage-cobertura-xml
     - cp tests/unit/coverage-cobertura.xml shippable/codecoverage
 
   on_success:
+    # Copy test results where shippable.io finds them
+    - make -C tests/unit check-junit-xml
+    - cp tests/unit/*.junit.xml shippable/testresults
+
+    # Report coverage results to codecov
     - bash <(curl -s https://codecov.io/bash)
+
+  on_failure:
+    # Dump test logs to stdout for debugging test failures
+    - for f in tests/unit/*.log; do echo "======= TEST LOG $f ======="; cat $f; done
+
+    # Copy test results where shippable.io finds them
+    - make -C tests/unit check-junit-xml
+    - cp tests/unit/*.junit.xml shippable/testresults

--- a/src/libosd/osd-private.h
+++ b/src/libosd/osd-private.h
@@ -137,7 +137,7 @@ static inline void timespec_add_ns(struct timespec *a, uint64_t ns)
 /**
  * zframe_dup() taking a const argument
  */
-inline zframe_t* zframe_dup_c(const zframe_t *self)
+static inline zframe_t* zframe_dup_c(const zframe_t *self)
 {
     return zframe_dup((zframe_t*)self);
 }
@@ -145,7 +145,7 @@ inline zframe_t* zframe_dup_c(const zframe_t *self)
 /**
  * zframe_eq() taking a const arguments
  */
-inline bool zframe_eq_c(const zframe_t *self, const zframe_t *other)
+static inline bool zframe_eq_c(const zframe_t *self, const zframe_t *other)
 {
     return zframe_eq((zframe_t*)self, (zframe_t*)other);
 }


### PR DESCRIPTION
... instead of treating the build as "failed" and not upload any test
reports. Unfortunately, shippable.io doesn't have a unconditional "after
ci" build step, so we need to place the relevant code in on_success as
well as in on_failure.